### PR TITLE
Finish MVP baseline for `/signup`

### DIFF
--- a/src/SignupPage.js
+++ b/src/SignupPage.js
@@ -96,29 +96,17 @@ class SignupPage extends Component {
 
   signup = (e) => {
     e.preventDefault();
-    const { firstname, lastname, username, password, occupation, gender } = this.state
-    //const { month, day, year, password_c, whichOccupation, touched, usernameValid, ...data } = this.state
-    const dob = "${this.state.month}${this.state.day}${this.state.year}"; // TODO valid y/n? TODO add firstname, lastname to db model
-    var res = this.props.dispatchSignup(
-        { firstname, lastname, username, password, occupation, gender, dob }
-    );
-    /*
-    fetch('http://localhost:5000/auth/signup', {
-      method: 'POST', headers: {
-        'Accept': 'application/json',
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify({
-        username: this.state.username,
-        email: '',
-        password: this.state.password,
-        occupation: this.state.occupation
-      })
-    }).then((response) => response.json())
-    .then((responseJson) => {
-      console.log(responseJson);
+    const { firstname, lastname, username, password, occupation, gender } = this.state // TODO add firstname, lastname to db model (?)
+    const dob = `${moment.monthsShort().indexOf(this.state.month)}-${this.state.day}-${this.state.year}`; // MM-DD-YYYY string
+    var res = this.props.dispatchSignup({ 
+      firstname,
+      lastname,
+      username,
+      password,
+      occupation,
+      gender,
+      dob
     });
-    console.log(e);*/
   }
 
   // Conditions hold `true` iff there is an error.

--- a/src/SignupPage.js
+++ b/src/SignupPage.js
@@ -47,8 +47,6 @@ class SignupPage extends Component {
       },
 
       usernameValid: true,
-      passwordsMatch: true,
-      headerLinks: ["Home"]
     };
   }
 
@@ -76,10 +74,6 @@ class SignupPage extends Component {
           this.setState({ usernameValid : res });
       });
     }
-
-    if(field === 'password_c') {
-      this.setState({ passwordsMatch: (this.state.password === this.state.password_c) });
-    }
   }
 
   handleInputChange = (e) => {
@@ -102,14 +96,13 @@ class SignupPage extends Component {
 
   signup = (e) => {
     e.preventDefault();
-    const { username, password } = this.state;
+    const { firstname, lastname, username, password, occupation, gender } = this.state
+    //const { month, day, year, password_c, whichOccupation, touched, usernameValid, ...data } = this.state
+    const dob = "${this.state.month}${this.state.day}${this.state.year}"; // TODO valid y/n? TODO add firstname, lastname to db model
     var res = this.props.dispatchSignup(
-      username,
-      '', // email
-      password,
-      ''  // occupation
+        { firstname, lastname, username, password, occupation, gender, dob }
     );
-    /*const dob = "${this.state.month}${this.state.day}${this.state.year}"; // TODO valid y/n? TODO db model
+    /*
     fetch('http://localhost:5000/auth/signup', {
       method: 'POST', headers: {
         'Accept': 'application/json',
@@ -142,7 +135,6 @@ class SignupPage extends Component {
   }
 
   render() {
-    const { headerLinks } = this.state;
     const { isLoggedIn, isSignedUp, usernameValid } = this.props;
     if(isLoggedIn) {
       return <Redirect to="/home"/>
@@ -157,7 +149,7 @@ class SignupPage extends Component {
 
     return (
       <div className="body">
-      <Header links={headerLinks} username=""/>
+      <Header/>
       
       <div className="container">
         <div className="row subcontainer">
@@ -219,7 +211,7 @@ class SignupPage extends Component {
                   <div className="column column-50">
                       <h2>RE-TYPE PASSWORD</h2>
                       <input className={markError('password_c') ? "error" : ""} onBlur={this.handleBlur('password_c')} placeholder="" name="password_c" type="password" onChange={this.handleInputChange}/>
-                      <div className={this.state.passwordsMatch? "warning-hide" : "warning"}>Oops, your passwords don't match.</div>
+                      <div className={(this.state.password === this.state.password_c) ? "warning-hide" : "warning"}>Oops, your passwords don't match.</div>
                   </div>
               </div>
 

--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -48,10 +48,10 @@ export const dispatchLogin = (username, password) => {
   }
 }
 
-export const dispatchSignup = (username, email, password, occupation) => {
+export const dispatchSignup = (data) => { 
   const endpoint = api_url + '/auth/signup';
   return function(dispatch) {
-    axios.post(endpoint, {username, email, password, occupation})
+    axios.post(endpoint, data)
     .then(res => {
       if(res.status !== 200) {
         dispatch(signupError());

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -23,7 +23,7 @@ const HeaderRight = props => {
     return (
         <ul className="navigation-list float-right">
             <li className="navigation-item">{props.username}</li>
-            {props.links.map((link, i) => {
+            { props.links === undefined ? "" : props.links.map((link, i) => {
                 const routePath = `/${link.toLowerCase()}`;
                 return (
                     <li className="navigation-item" key={i}>

--- a/src/style/SignupPage.css
+++ b/src/style/SignupPage.css
@@ -63,7 +63,7 @@
   margin-top: 1.6em; }
 
 .password {
-  margin-top: 0.8em; }
+  margin-top: 0.4em; }
 
 .gender {
   margin-top: 2em; }

--- a/src/style/SignupPage.scss
+++ b/src/style/SignupPage.scss
@@ -96,7 +96,7 @@ $transition-delta2: 0.2s;
 }
 
 .password {
-  margin-top: 0.8em;
+  margin-top: 0.4em;
 }
 
 .gender {


### PR DESCRIPTION
__this PR__
- remove `Home` from navbar, fix `Header` component to allow this behavior
- db on AWS now has `firstname`, `lastname` columns
- more input validation fiddling (dropdowns, radiobuttons)

__to do__
if extra time b/w end of next task (`/profile`) & MVP launch:
- fix resizing behavior when `width < 720px`
- stricter validation for first/last/username, password
- clean up css (unused classes, redundant pseudoselectors etc.)

will move on to `\profile` now