### PR TITLE
MVP baseline for `/profile`

### DIFF
--- a/src/ProfilePage.js
+++ b/src/ProfilePage.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { Redirect } from 'react-router-dom';
-import { dispatchLogin } from './actions/auth';
+import { dispatchPassword } from './actions/auth';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import Header from './components/header';
@@ -12,8 +12,11 @@ class Profile extends Component {
     super(props);
     this.state = {
       headerLinks: ["Learn", "Progress", "Home"],
+      edited: false,
       editing: false,
-      password: " ",
+      viewing: false,
+      username: "foobar", // TODO not hardcode 
+      password: "TEMP",
       touched: {
         password: false
       }
@@ -21,13 +24,21 @@ class Profile extends Component {
   }
 
   editPassword = () => {
-    this.setState({ editing: true });
-    // TODO call dispatch
-    console.log('edit');
+    if(!this.state.editing)
+      this.setState({ editing: true });
+    else {
+      const { username, password } = this.state;
+      var res = this.props.dispatchPassword(
+        username,
+        password
+      );
+      console.log(res);
+      this.setState({ editing: false, edited: true });
+    }
   }
 
-  viewPassword = () => {
-    console.log('view');
+  toggleViewing = () => {
+    this.setState({ viewing: !this.state.viewing });
   }
 
   handleBlur = (e) => {
@@ -76,7 +87,7 @@ class Profile extends Component {
               </div>
               <div className="column column-10"></div>
               <div className="column column-50">
-                <p>p_torres</p>
+                <p>{this.state.username}</p>
               </div>
             </div>
 
@@ -86,7 +97,10 @@ class Profile extends Component {
               </div>
               <div className="column column-20 column-offset-10 password-info">
                 <p className={ this.state.editing ? "hide" : ""}>
-                  ******
+                  { this.state.viewing ? this.state.password : '*'.repeat(this.state.password.length) }
+
+                  {/* TODO this is pretty egregiously insecure} */}
+
                 </p>
                 <input className={ this.state.editing ? (markError() ? "error" : "") : "hide" } placeholder="" name="password" type="password" onBlur={this.handleBlur} onChange={this.handleInputChange}/>
               </div>
@@ -94,10 +108,12 @@ class Profile extends Component {
               <div className="column column-30 options">
                 <div className="options">
                   <button onClick={this.editPassword}>
-                    <span className={this.state.editing ? "hide" : ""}>EDIT</span>
-                    <span className={this.state.editing ? "" : "hide"}>SUBMIT</span>
+                    <span className={ this.state.editing ? "hide" : "" }>EDIT</span>
+                    <span className={ this.state.editing ? "" : "hide" }>SUBMIT</span>
                   </button>
-                  <button onClick={this.viewPassword}>VIEW</button>
+                  <button className={ this.state.edited ? "" : "hide" } onClick={ this.toggleViewing }>
+                    { this.state.viewing ? "HIDE" : "VIEW" } 
+                  </button>
                 </div>
               </div>
 
@@ -118,7 +134,7 @@ const mapStateToProps = state => {
 }
 
 const mapDispatchToProps = dispatch => {
-  return bindActionCreators({ dispatchLogin }, dispatch);
+  return bindActionCreators({ dispatchPassword }, dispatch);
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(Profile);

--- a/src/ProfilePage.js
+++ b/src/ProfilePage.js
@@ -11,12 +11,47 @@ class Profile extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      headerLinks: ["Learn", "Progress", "Home"]
+      headerLinks: ["Learn", "Progress", "Home"],
+      editing: false,
+      password: " ",
+      touched: {
+        password: false
+      }
+    }
+  }
+
+  editPassword = () => {
+    this.setState({ editing: true });
+    // TODO call dispatch
+    console.log('edit');
+  }
+
+  viewPassword = () => {
+    console.log('view');
+  }
+
+  handleBlur = (e) => {
+    this.setState({
+      touched: { password : true }
+    });
+  }
+
+  handleInputChange = (e) => {
+    this.setState({ [e.target.name] : e.target.value });
+  }
+
+  validate = (password) => {
+    return {
+      password: password.length === 0
     }
   }
 
   render() {
     const { headerLinks } = this.state;
+    const errors = this.validate(this.state.password);
+    const markError = () => {
+      return errors['password'] ? this.state.touched['password'] : false;
+    }
 
     return (
       <div>
@@ -47,38 +82,25 @@ class Profile extends Component {
 
             <div className="row">
               <div className="column column-33">
-                <h3>Email</h3>
-              </div>
-              <div className="column column-10"></div>
-              <div className="column column-50">
-                <p>phil.torres@typephil.com</p>
-              </div>
-            </div>
-            
-            <div className="row">
-              <div className="column column-33">
                 <h3>Password</h3>
               </div>
-              <div className="column column-10"></div>
-              <div className="column column-10">
-                <p>******</p>
+              <div className="column column-20 column-offset-10 password-info">
+                <p className={ this.state.editing ? "hide" : ""}>
+                  ******
+                </p>
+                <input className={ this.state.editing ? (markError() ? "error" : "") : "hide" } placeholder="" name="password" type="password" onBlur={this.handleBlur} onChange={this.handleInputChange}/>
               </div>
 
-              <div className="column column-20 options">
+              <div className="column column-30 options">
                 <div className="options">
-                  <button>EDIT</button>
-                  <button>VIEW</button>
+                  <button onClick={this.editPassword}>
+                    <span className={this.state.editing ? "hide" : ""}>EDIT</span>
+                    <span className={this.state.editing ? "" : "hide"}>SUBMIT</span>
+                  </button>
+                  <button onClick={this.viewPassword}>VIEW</button>
                 </div>
               </div>
 
-                {/*
-                <div className="highlight" id="view">
-                  <div className="eye"></div>
-                </div>
-                <div className="highlight" id="edit">
-                  <img src="images/universal/Pencil.png"></img>
-                </div>
-                */}
             </div>
           </div>
         </div>

--- a/src/ProfilePage.js
+++ b/src/ProfilePage.js
@@ -26,16 +26,7 @@ class Profile extends Component {
         <div className="vert-container">
           <div className="panel">
             <div className="row top">
-              {/* 
-              <div className="column column-50">
 
-                <div id="profile-pic">
-                  <img src="images/universal/Profile_pic.svg"></img>
-                </div>
-
-              </div>
-              <div className="column column-50">
-              */}
               <div className="column column-100">
                 <h2>Name</h2>
                 <h1>Phil Torres</h1>
@@ -69,17 +60,25 @@ class Profile extends Component {
                 <h3>Password</h3>
               </div>
               <div className="column column-10"></div>
-              <div className="column column-20">
+              <div className="column column-10">
                 <p>******</p>
               </div>
-              <div className="column column-10">
+
+              <div className="column column-20 options">
+                <div className="options">
+                  <button>EDIT</button>
+                  <button>VIEW</button>
+                </div>
+              </div>
+
+                {/*
                 <div className="highlight" id="view">
                   <div className="eye"></div>
                 </div>
                 <div className="highlight" id="edit">
                   <img src="images/universal/Pencil.png"></img>
                 </div>
-              </div>
+                */}
             </div>
           </div>
         </div>

--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -63,6 +63,21 @@ export const dispatchSignup = (data) => {
   }
 }
 
+export const dispatchPassword = (username, password) => {
+  const endpoint = api_url + '/auth/newPassword';
+  return function(dispatch) {
+    axios.post(endpoint, {username, password})
+    .then(res => {
+      if(res.status !== 200) {
+        console.log('err'); // TODO fix
+      }
+      console.log('good');
+    }).catch(err => {
+      console.log('err');
+    });
+  }
+}
+
 /*export const dispatchUsername = (username) => {
   const endpoint = api_url + '/auth/usernameValid';
   return function(dispatch) {

--- a/src/style/ProfilePage.css
+++ b/src/style/ProfilePage.css
@@ -82,13 +82,13 @@ p {
     width: 100px; }
 
 .options {
-  -webkit-transition: border-left 0.05s ease-in-out;
-  -moz-transition: border-left 0.05s ease-in-out;
-  -ms-transition: border-left 0.05s ease-in-out;
-  -o-transition: border-left 0.05s ease-in-out;
   float: left;
   margin-top: -2px; }
   .options button {
+    -webkit-transition-duration: 0.08s;
+    -moz-transition-duration: 0.08s;
+    -ms-transition-duration: 0.08s;
+    -o-transition-duration: 0.08s;
     background-color: #A2A3A4;
     font-size: 60%;
     height: 25px;

--- a/src/style/ProfilePage.css
+++ b/src/style/ProfilePage.css
@@ -29,6 +29,9 @@ p {
   margin: 0 auto;
   text-align: left; }
 
+input[type="password"] {
+  height: 24px; }
+
 .container {
   height: 70vh;
   max-height: 70vh;
@@ -45,14 +48,15 @@ p {
   height: inherit;
   width: 100%; }
 
+/*
 .eye {
   width: 13px;
   height: 13px;
   border: solid 1px #000;
-  border-radius: 75% 15%;
+  border-radius:  75% 15%;
   position: relative;
-  transform: rotate(45deg); }
-
+  transform: rotate(45deg);
+}
 .eye:before {
   content: '';
   display: inline-block;
@@ -62,12 +66,19 @@ p {
   border: solid 1px #000;
   border-radius: 50%;
   left: 3px;
-  top: 3px; }
+  top: 3px;
+}
+*/
+.hide {
+  display: none; }
 
 .panel {
   margin: 0 auto;
   position: relative;
   width: 60%; }
+
+.password-info {
+  margin-top: -2px; }
 
 .top {
   margin-bottom: 2vh;
@@ -83,26 +94,31 @@ p {
 
 .options {
   float: left;
-  margin-top: -2px; }
+  margin-left: -18px;
+  margin-top: -1px; }
   .options button {
     -webkit-transition-duration: 0.06s;
     -moz-transition-duration: 0.06s;
     -ms-transition-duration: 0.06s;
     -o-transition-duration: 0.06s;
-    background-color: #A2A3A4;
+    background-color: #52B094;
+    border: 1px solid #52B094;
+    border-radius: 0;
     font-size: 60%;
-    height: 25px;
-    line-height: 25px;
-    width: 50px;
+    height: 24px;
+    line-height: 24px;
     min-width: 50px;
     margin: 0 2px;
     padding: 0 10px;
     text-align: center; }
     .options button:hover {
-      background-color: #555555;
-      border: none;
+      background-color: #68C3A3;
+      border: 1px solid #68C3A3;
       color: #DADFE1; }
-    .options button:active, .options button:focus, .options button::-moz-focus-inner {
+    .options button:active, .options button:focus {
+      border: 1px solid #68C3A3;
+      outline: 0; }
+    .options button::-moz-focus-inner {
       border: none;
       outline: 0; }
 

--- a/src/style/ProfilePage.css
+++ b/src/style/ProfilePage.css
@@ -85,10 +85,10 @@ p {
   float: left;
   margin-top: -2px; }
   .options button {
-    -webkit-transition-duration: 0.08s;
-    -moz-transition-duration: 0.08s;
-    -ms-transition-duration: 0.08s;
-    -o-transition-duration: 0.08s;
+    -webkit-transition-duration: 0.06s;
+    -moz-transition-duration: 0.06s;
+    -ms-transition-duration: 0.06s;
+    -o-transition-duration: 0.06s;
     background-color: #A2A3A4;
     font-size: 60%;
     height: 25px;
@@ -98,8 +98,13 @@ p {
     margin: 0 2px;
     padding: 0 10px;
     text-align: center; }
-    .options button:hover, .options button:active {
-      background-color: #555555; }
+    .options button:hover {
+      background-color: #555555;
+      border: none;
+      color: #DADFE1; }
+    .options button:active, .options button:focus, .options button::-moz-focus-inner {
+      border: none;
+      outline: 0; }
 
 #view {
   float: left; }

--- a/src/style/ProfilePage.css
+++ b/src/style/ProfilePage.css
@@ -81,16 +81,25 @@ p {
     height: 100px;
     width: 100px; }
 
-.highlight {
+.options {
   -webkit-transition: border-left 0.05s ease-in-out;
   -moz-transition: border-left 0.05s ease-in-out;
   -ms-transition: border-left 0.05s ease-in-out;
   -o-transition: border-left 0.05s ease-in-out;
-  width: 40%;
-  padding-left: 10px; }
-  .highlight:hover {
-    border-left: solid 3px #52B094;
-    padding-left: 7px; }
+  float: left;
+  margin-top: -2px; }
+  .options button {
+    background-color: #A2A3A4;
+    font-size: 60%;
+    height: 25px;
+    line-height: 25px;
+    width: 50px;
+    min-width: 50px;
+    margin: 0 2px;
+    padding: 0 10px;
+    text-align: center; }
+    .options button:hover, .options button:active {
+      background-color: #555555; }
 
 #view {
   float: left; }

--- a/src/style/ProfilePage.scss
+++ b/src/style/ProfilePage.scss
@@ -11,7 +11,7 @@ $menu-gray: #A2A3A4;
 $container-height: 70vh;
 $image-dim: 100px;
 
-$transition-delta: 0.05s;
+$transition-delta: 0.08s;
 $button-width: 50px;
 
 body {
@@ -107,14 +107,15 @@ p {
 }
 
 .options {
-  -webkit-transition: border-left $transition-delta ease-in-out;
-  -moz-transition: border-left $transition-delta ease-in-out;
-  -ms-transition: border-left $transition-delta ease-in-out;
-  -o-transition: border-left $transition-delta ease-in-out;
   float: left;
   margin-top: -2px;
 
   button {
+    -webkit-transition-duration: $transition-delta;
+    -moz-transition-duration: $transition-delta;
+    -ms-transition-duration: $transition-delta;
+    -o-transition-duration: $transition-delta;
+
     background-color: $menu-gray; //$palm-green;
     font-size: 60%;
     height: $button-width / 2;

--- a/src/style/ProfilePage.scss
+++ b/src/style/ProfilePage.scss
@@ -47,6 +47,10 @@ p {
   text-align: left;
 }
 
+input[type="password"] {
+  height: $button-width / 2 - 1px;
+}
+
 .container {
   height: $container-height;
   max-height: 70vh;
@@ -65,6 +69,7 @@ p {
   width: 100%;
 }
 
+/*
 .eye {
   width: 13px;
   height: 13px;
@@ -84,11 +89,20 @@ p {
   left: 3px;
   top: 3px;
 }
+*/
+
+.hide {
+  display: none;
+}
 
 .panel {
   margin: 0 auto;
   position: relative;
   width: 60%;
+}
+
+.password-info {
+  margin-top: -2px;
 }
 
 .top {
@@ -108,7 +122,8 @@ p {
 
 .options {
   float: left;
-  margin-top: -2px;
+  margin-left: -18px;
+  margin-top: -1px;
 
   button {
     -webkit-transition-duration: $transition-delta;
@@ -116,25 +131,31 @@ p {
     -ms-transition-duration: $transition-delta;
     -o-transition-duration: $transition-delta;
 
-    background-color: $menu-gray; //$palm-green;
+    background-color: $palm-green;
+    border: 1px solid $palm-green;
+    border-radius: 0;
     font-size: 60%;
-    height: $button-width / 2;
-    line-height: $button-width / 2;
-    width: $button-width;
+    height: $button-width / 2 - 1px;
+    line-height: $button-width / 2 - 1px;
+    //width: $button-width;
     min-width: $button-width;
     margin: 0 2px;
     padding: 0 $button-width / 5;
     text-align: center;
     &:hover {
-      background-color: $hover-dark;
-      border: none;
+      background-color: $silver-tree;
+      border: 1px solid $silver-tree;
       color: $hover-light;
     }
-    &:active, &:focus, &::-moz-focus-inner {
-      border: none;
+    &:active, &:focus {
+      border: 1px solid $silver-tree;
       outline: 0;
     }
-  }
+    &::-moz-focus-inner {
+      border:  none;
+      outline: 0;
+    }
+  } 
 }
 
 #view {

--- a/src/style/ProfilePage.scss
+++ b/src/style/ProfilePage.scss
@@ -11,7 +11,7 @@ $menu-gray: #A2A3A4;
 $container-height: 70vh;
 $image-dim: 100px;
 
-$transition-delta: 0.08s;
+$transition-delta: 0.06s;
 $button-width: 50px;
 
 body {
@@ -125,8 +125,14 @@ p {
     margin: 0 2px;
     padding: 0 $button-width / 5;
     text-align: center;
-    &:hover, &:active {
+    &:hover {
       background-color: $hover-dark;
+      border: none;
+      color: $hover-light;
+    }
+    &:active, &:focus, &::-moz-focus-inner {
+      border: none;
+      outline: 0;
     }
   }
 }

--- a/src/style/ProfilePage.scss
+++ b/src/style/ProfilePage.scss
@@ -12,6 +12,7 @@ $container-height: 70vh;
 $image-dim: 100px;
 
 $transition-delta: 0.05s;
+$button-width: 50px;
 
 body {
   font-family: 'Nunito Sans', 'Open Sans', 'sans-serif';
@@ -105,17 +106,27 @@ p {
   }
 }
 
-.highlight {
+.options {
   -webkit-transition: border-left $transition-delta ease-in-out;
   -moz-transition: border-left $transition-delta ease-in-out;
   -ms-transition: border-left $transition-delta ease-in-out;
   -o-transition: border-left $transition-delta ease-in-out;
-  width: 40%;
+  float: left;
+  margin-top: -2px;
 
-  padding-left: 10px;
-  &:hover {
-    border-left: solid 3px $palm-green;
-    padding-left: 7px;
+  button {
+    background-color: $menu-gray; //$palm-green;
+    font-size: 60%;
+    height: $button-width / 2;
+    line-height: $button-width / 2;
+    width: $button-width;
+    min-width: $button-width;
+    margin: 0 2px;
+    padding: 0 $button-width / 5;
+    text-align: center;
+    &:hover, &:active {
+      background-color: $hover-dark;
+    }
   }
 }
 


### PR DESCRIPTION
this is the frontend update that goes with [#4](https://github.com/codephil-columbia/lavazares/pull/4)
***
- replace _eye_ and _pencil_ images with text buttons for convenience
- remove `email` field (we don't yet request it during onboarding flow)
- enable __View__ password, but only after it's been edited
    - passwords are one-way hashed in db, so it's impossible to view an existing password unless we store it in plaintext or similar
- enable __Edit__ password

![](https://i.imgur.com/jLYtdsB.gif)

__TODO__
`/profile` doesn't yet grab current user from `session`/`localstorage`, do this