### PR TITLE
Change auth reducer to prevent 404s 

### DIFF
--- a/src/HomePage.js
+++ b/src/HomePage.js
@@ -51,6 +51,7 @@ class HomePage extends Component {
   }
 
   render() {
+    console.log(this.props);
     const { 
       badges, 
       headerLinks, 

--- a/src/app.js
+++ b/src/app.js
@@ -46,8 +46,8 @@ class App extends Component {
         <Route path="/tutorial" component={Tutorial}/>
         <Route path="/profile" component={Profile}/>
         <Route path="/signup" component={() => <SignupPage onSuccessfulAuth={this.onSuccessfulAuth}/>}/>
-        <Route path="/" component={HomePage}/>//component={() => <LoginPage onSuccessfulAuth={this.onSuccessfulAuth}/>}/>
-        <Route component={FourOhFour} />
+        <Route path="/" component={HomePage}/>
+        <Route path="/404"component={FourOhFour} />
       </Switch>
     )
   }

--- a/src/store.js
+++ b/src/store.js
@@ -8,7 +8,6 @@ import { combineReducers } from 'redux';
 import requestTextConverter from './middleware/requestTextConverter';
 
 import {
-  isLoggedIn,
   app as appReducer
 } from './reducers';
 
@@ -31,14 +30,14 @@ localforage.config({
 
 const persistConfig = {
   storage: localforage,
-  whitelist: ['auth', 'isLoggedIn', 'currentUser', 'currentLesson', 'chosenLessonFromLearn'],
+  whitelist: ['currentLesson', 'chosenLessonFromLearn'],
   key: 'root',
   debug: true
 }
 
 const persistAuthConfig = {
   storage: localforage,
-  whitelist: ['auth' ],
+  whitelist: ['currentUser', 'isLoggedIn'],
   key: 'auth',
   debug: true
 }


### PR DESCRIPTION
I've noticed that `persistAuthConfig` might not be be saving the `isLoggedIn` flag that app.js uses to decide whether to show the protected routes + their components due to the way that redux persist reconciles state during a rehydration (https://github.com/rt2zz/redux-persist#state-reconciler). Whitelisting `currentUser` and `isLoggedIn` separately seem to fix the issue 
Lmk what you think, since you've worked with persist more than I have